### PR TITLE
Add REST API call features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+.idea/discord.xml

--- a/.idea/discord.xml
+++ b/.idea/discord.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DiscordProjectSettings">
+    <option name="show" value="PROJECT_FILES" />
+    <option name="description" value="" />
+  </component>
+</project>

--- a/.idea/discord.xml
+++ b/.idea/discord.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="DiscordProjectSettings">
-    <option name="show" value="PROJECT_FILES" />
-    <option name="description" value="" />
-  </component>
-</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,7 +3,8 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
-        <entry key="app/src/main/res/layout/activity_main.xml" value="0.17255434782608695" />
+        <entry key="app/src/main/res/layout/activity_apiactivity.xml" value="0.31837606837606836" />
+        <entry key="app/src/main/res/layout/activity_main.xml" value="0.25" />
       </map>
     </option>
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,4 +35,5 @@ dependencies {
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation 'com.android.volley:volley:1.1.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.cp3407.wildernessweather">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,9 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.WildernessWeather">
         <activity
+            android:name=".APIactivity"
+            android:exported="true" />
+        <activity
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/cp3407/wildernessweather/APIactivity.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/APIactivity.java
@@ -1,0 +1,59 @@
+package com.cp3407.wildernessweather;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ListView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import java.util.List;
+
+public class APIactivity extends AppCompatActivity {
+
+    EditText searchBox;
+    Button getWeatherData;
+    ListView weatherReports;
+    WeatherDataService weatherDataService;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_apiactivity);
+
+        searchBox = findViewById(R.id.et_searchBox);
+        getWeatherData = findViewById(R.id.btn_getWeatherData);
+        weatherReports = findViewById(R.id.lv_weatherReports);
+
+        weatherDataService = new WeatherDataService(APIactivity.this);
+    }
+
+    public void getWeatherPressed(View view) {
+
+        weatherDataService.getCityID(searchBox.getText().toString(), new WeatherDataService.GetCityIDResponseListener() {
+            @Override
+            public void onError(String message) {
+                Toast.makeText(APIactivity.this, "Something went wrong", Toast.LENGTH_SHORT).show();
+            }
+
+            @Override
+            public void onResponse(String cityID) {
+                weatherDataService.getCityForecastByID(cityID, new WeatherDataService.ForecastByIDResponseListener() {
+                    @Override
+                    public void onError(String message) {
+                        Toast.makeText(APIactivity.this, "Something went wrong, could not get weather data", Toast.LENGTH_SHORT).show();
+                    }
+
+                    @Override
+                    public void onResponse(List<WeatherReportModel> weatherReportModels) {
+                        ArrayAdapter arrayAdapter = new ArrayAdapter(APIactivity.this, android.R.layout.simple_list_item_1, weatherReportModels);
+                        weatherReports.setAdapter(arrayAdapter);
+                    }
+                });
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/cp3407/wildernessweather/MainActivity.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/MainActivity.java
@@ -30,7 +30,7 @@ public class MainActivity extends AppCompatActivity {
     public void getCityIdPressed(View view) {
 
         // Brisbane is temporarily hardcoded for testing
-        weatherDataService.getCityID("brisbane", new WeatherDataService.VolleyResponseListener() {
+        weatherDataService.getCityID("brisbane", new WeatherDataService.GetCityIDResponseListener() {
             @Override
             public void onError(String message) {
                 Toast.makeText(MainActivity.this, "Something went wrong", Toast.LENGTH_SHORT).show();
@@ -44,6 +44,16 @@ public class MainActivity extends AppCompatActivity {
     }
 
     public void getWeatherPressed(View view) {
-        weatherDataService.getCityForecastByID("1100661");
+        weatherDataService.getCityForecastByID("1100661", new WeatherDataService.ForecastByIDResponseListener() {
+            @Override
+            public void onError(String message) {
+                Toast.makeText(MainActivity.this, "Something went wrong", Toast.LENGTH_SHORT).show();
+            }
+
+            @Override
+            public void onResponse(WeatherReportModel weatherReportModel) {
+                Toast.makeText(MainActivity.this, "This is what you got back: " + weatherReportModel.toString(), Toast.LENGTH_SHORT).show();
+            }
+        });
     }
 }

--- a/app/src/main/java/com/cp3407/wildernessweather/MainActivity.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/MainActivity.java
@@ -8,36 +8,42 @@ import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.android.volley.Request;
-import com.android.volley.RequestQueue;
-import com.android.volley.toolbox.JsonObjectRequest;
-import com.android.volley.toolbox.Volley;
-
 public class MainActivity extends AppCompatActivity {
 
     Button getWeatherData;
     TextView weatherData;
+
+    WeatherDataService weatherDataService;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        getWeatherData = findViewById(R.id.btn_getWeather);
+        getWeatherData = findViewById(R.id.btn_getCityID);
         weatherData = findViewById(R.id.tv_weatherView);
+
+        weatherDataService = new WeatherDataService(MainActivity.this);
+
+    }
+
+    public void getCityIdPressed(View view) {
+
+        // Brisbane is temporarily hardcoded for testing
+        weatherDataService.getCityID("brisbane", new WeatherDataService.VolleyResponseListener() {
+            @Override
+            public void onError(String message) {
+                Toast.makeText(MainActivity.this, "Something went wrong", Toast.LENGTH_SHORT).show();
+            }
+
+            @Override
+            public void onResponse(String cityID) {
+                Toast.makeText(MainActivity.this, "Returned an ID of " + cityID, Toast.LENGTH_SHORT).show();
+            }
+        });
     }
 
     public void getWeatherPressed(View view) {
-        // Instantiate the RequestQueue
-        RequestQueue queue = Volley.newRequestQueue(MainActivity.this);
-        String url = "https://www.metaweather.com/api/location/1100661/"; // 1100661 is the code for Brisbane. Just hardcoded for now while prototyping.
-
-        // Request string response
-        JsonObjectRequest request = new JsonObjectRequest(Request.Method.GET, url, null, response -> {
-            weatherData.setText(response.toString());
-            Toast.makeText(MainActivity.this, "Success", Toast.LENGTH_SHORT).show();
-        }, error -> Toast.makeText(MainActivity.this, "failed", Toast.LENGTH_SHORT).show());
-        // Add the request to the RequestQueue
-        queue.add(request);
+        weatherDataService.getCityForecastByID("1100661");
     }
 }

--- a/app/src/main/java/com/cp3407/wildernessweather/MainActivity.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/MainActivity.java
@@ -3,12 +3,61 @@ package com.cp3407.wildernessweather;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.Response;
+import com.android.volley.VolleyError;
+import com.android.volley.toolbox.JsonArrayRequest;
+import com.android.volley.toolbox.StringRequest;
+import com.android.volley.toolbox.Volley;
+
+import org.json.JSONArray;
 
 public class MainActivity extends AppCompatActivity {
+
+    Button getWeatherData;
+    TextView weatherData;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        getWeatherData = findViewById(R.id.btn_getWeather);
+        weatherData = findViewById(R.id.tv_weatherView);
+
+        getWeatherData.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View view) {
+
+                //Instantiate the RequestQueue
+                RequestQueue queue = Volley.newRequestQueue(MainActivity.this);
+                String url = "https://www.metaweather.com/api/location/search/?query=london";
+
+                // Request string response
+                StringRequest stringRequest = new StringRequest(Request.Method.GET, url, new Response.Listener<String>() {
+                    @Override
+                    public void onResponse(String response) {
+                        Toast.makeText(MainActivity.this, response, Toast.LENGTH_SHORT).show();
+                    }
+                }, new Response.ErrorListener() {
+                    @Override
+                    public void onErrorResponse(VolleyError error) {
+                        Toast.makeText(MainActivity.this, "Failed", Toast.LENGTH_SHORT).show();
+                    }
+                });
+
+                // Add request to the RequestQueue
+                queue.add(stringRequest);
+            }
+        });
     }
+
+
 }

--- a/app/src/main/java/com/cp3407/wildernessweather/MainActivity.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/MainActivity.java
@@ -1,22 +1,17 @@
 package com.cp3407.wildernessweather;
 
-import androidx.appcompat.app.AppCompatActivity;
-
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.appcompat.app.AppCompatActivity;
+
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
-import com.android.volley.Response;
-import com.android.volley.VolleyError;
-import com.android.volley.toolbox.JsonArrayRequest;
-import com.android.volley.toolbox.StringRequest;
+import com.android.volley.toolbox.JsonObjectRequest;
 import com.android.volley.toolbox.Volley;
-
-import org.json.JSONArray;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -30,34 +25,19 @@ public class MainActivity extends AppCompatActivity {
 
         getWeatherData = findViewById(R.id.btn_getWeather);
         weatherData = findViewById(R.id.tv_weatherView);
-
-        getWeatherData.setOnClickListener(new View.OnClickListener() {
-
-            @Override
-            public void onClick(View view) {
-
-                //Instantiate the RequestQueue
-                RequestQueue queue = Volley.newRequestQueue(MainActivity.this);
-                String url = "https://www.metaweather.com/api/location/search/?query=london";
-
-                // Request string response
-                StringRequest stringRequest = new StringRequest(Request.Method.GET, url, new Response.Listener<String>() {
-                    @Override
-                    public void onResponse(String response) {
-                        Toast.makeText(MainActivity.this, response, Toast.LENGTH_SHORT).show();
-                    }
-                }, new Response.ErrorListener() {
-                    @Override
-                    public void onErrorResponse(VolleyError error) {
-                        Toast.makeText(MainActivity.this, "Failed", Toast.LENGTH_SHORT).show();
-                    }
-                });
-
-                // Add request to the RequestQueue
-                queue.add(stringRequest);
-            }
-        });
     }
 
+    public void getWeatherPressed(View view) {
+        // Instantiate the RequestQueue
+        RequestQueue queue = Volley.newRequestQueue(MainActivity.this);
+        String url = "https://www.metaweather.com/api/location/1100661/"; // 1100661 is the code for Brisbane. Just hardcoded for now while prototyping.
 
+        // Request string response
+        JsonObjectRequest request = new JsonObjectRequest(Request.Method.GET, url, null, response -> {
+            weatherData.setText(response.toString());
+            Toast.makeText(MainActivity.this, "Success", Toast.LENGTH_SHORT).show();
+        }, error -> Toast.makeText(MainActivity.this, "failed", Toast.LENGTH_SHORT).show());
+        // Add the request to the RequestQueue
+        queue.add(request);
+    }
 }

--- a/app/src/main/java/com/cp3407/wildernessweather/MainActivity.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/MainActivity.java
@@ -1,59 +1,26 @@
 package com.cp3407.wildernessweather;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
-import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
 public class MainActivity extends AppCompatActivity {
 
-    Button getWeatherData;
-    TextView weatherData;
-
-    WeatherDataService weatherDataService;
+    Button apiPrototype;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        getWeatherData = findViewById(R.id.btn_getCityID);
-        weatherData = findViewById(R.id.tv_weatherView);
-
-        weatherDataService = new WeatherDataService(MainActivity.this);
-
+        apiPrototype = findViewById(R.id.btn_apiPrototype);
     }
 
-    public void getCityIdPressed(View view) {
-
-        // Brisbane is temporarily hardcoded for testing
-        weatherDataService.getCityID("brisbane", new WeatherDataService.GetCityIDResponseListener() {
-            @Override
-            public void onError(String message) {
-                Toast.makeText(MainActivity.this, "Something went wrong", Toast.LENGTH_SHORT).show();
-            }
-
-            @Override
-            public void onResponse(String cityID) {
-                Toast.makeText(MainActivity.this, "Returned an ID of " + cityID, Toast.LENGTH_SHORT).show();
-            }
-        });
-    }
-
-    public void getWeatherPressed(View view) {
-        weatherDataService.getCityForecastByID("1100661", new WeatherDataService.ForecastByIDResponseListener() {
-            @Override
-            public void onError(String message) {
-                Toast.makeText(MainActivity.this, "Something went wrong", Toast.LENGTH_SHORT).show();
-            }
-
-            @Override
-            public void onResponse(WeatherReportModel weatherReportModel) {
-                Toast.makeText(MainActivity.this, "This is what you got back: " + weatherReportModel.toString(), Toast.LENGTH_SHORT).show();
-            }
-        });
+    public void apiPrototypePressed(View view) {
+        Intent intent = new Intent(this, APIactivity.class);
+        startActivity(intent);
     }
 }

--- a/app/src/main/java/com/cp3407/wildernessweather/Singleton.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/Singleton.java
@@ -1,0 +1,36 @@
+package com.cp3407.wildernessweather;
+
+import android.content.Context;
+
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.toolbox.Volley;
+
+public class Singleton {
+    private static Singleton instance;
+    private RequestQueue requestQueue;
+    private static Context ctx;
+
+    private Singleton(Context context) {
+        ctx = context;
+        requestQueue = getRequestQueue();
+    }
+
+    public static synchronized Singleton getInstance(Context context) {
+        if (instance == null) {
+            instance = new Singleton(context);
+        }
+        return instance;
+    }
+
+    public RequestQueue getRequestQueue() {
+        if (requestQueue == null) {
+            requestQueue = Volley.newRequestQueue(ctx.getApplicationContext());
+        }
+        return requestQueue;
+    }
+
+    public <T> void addToRequestQueue(Request<T> req) {
+        getRequestQueue().add(req);
+    }
+}

--- a/app/src/main/java/com/cp3407/wildernessweather/WeatherDataService.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/WeatherDataService.java
@@ -1,0 +1,83 @@
+package com.cp3407.wildernessweather;
+
+import android.content.Context;
+import android.widget.Toast;
+
+import com.android.volley.Request;
+import com.android.volley.Response;
+import com.android.volley.VolleyError;
+import com.android.volley.toolbox.JsonArrayRequest;
+import com.android.volley.toolbox.JsonObjectRequest;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WeatherDataService {
+
+    public static final String QUERY_FOR_CITY_ID = "https://www.metaweather.com/api/location/search/?query=";
+    public static final String QUERY_FOR_WEATHER_REPORT = "https://www.metaweather.com/api/location/";
+    Context context;
+    String cityID;
+
+    public WeatherDataService(Context context) {
+        this.context = context;
+    }
+
+    public interface VolleyResponseListener {
+        void onError(String message);
+
+        void onResponse(String cityID);
+    }
+
+    public void getCityID(String cityName, VolleyResponseListener volleyResponseListener) {
+        String url = QUERY_FOR_CITY_ID + cityName;
+
+        JsonArrayRequest request = new JsonArrayRequest(Request.Method.GET, url, null, new Response.Listener<JSONArray>() {
+            @Override
+            public void onResponse(JSONArray response) {
+                cityID = "";
+                try {
+                    JSONObject cityInfo = response.getJSONObject(0);
+                    cityID = cityInfo.getString("woeid");
+                } catch (JSONException e) {
+                    e.printStackTrace();
+                }
+                volleyResponseListener.onResponse(cityID);
+            }
+        }, new Response.ErrorListener() {
+            @Override
+            public void onErrorResponse(VolleyError error) {
+                volleyResponseListener.onError("Something went wrong");
+            }
+        });
+        Singleton.getInstance(context).addToRequestQueue(request);
+    }
+
+    public void getCityForecastByID(String cityID) {
+        List<WeatherReportModel> report = new ArrayList<>();
+        String url = QUERY_FOR_WEATHER_REPORT + cityID + "/";
+
+        JsonObjectRequest request = new JsonObjectRequest(Request.Method.GET, url, null, new Response.Listener<JSONObject>() {
+            @Override
+            public void onResponse(JSONObject response) {
+                Toast.makeText(context, "you got " + response.toString(), Toast.LENGTH_SHORT).show();
+            }
+        }, new Response.ErrorListener() {
+            @Override
+            public void onErrorResponse(VolleyError error) {
+                Toast.makeText(context, "failed", Toast.LENGTH_SHORT).show();
+            }
+        });
+        Singleton.getInstance(context).addToRequestQueue(request);
+
+    }
+//
+//    public List<WeatherReportModel> getCityForecastByName(String cityName) {
+//
+//    }
+
+}

--- a/app/src/main/java/com/cp3407/wildernessweather/WeatherReportModel.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/WeatherReportModel.java
@@ -1,0 +1,186 @@
+package com.cp3407.wildernessweather;
+
+public class WeatherReportModel {
+
+    // Properties from metaweather REST api data
+
+    private int id;
+    private String weather_state_name;
+    private String weather_state_abbr;
+    private String wind_direction_compass;
+    private String created;
+    private String applicable_date;
+    private float min_temp;
+    private float max_temp;
+    private float the_temp;
+    private float wind_speed;
+    private float wind_direction;
+    private int air_pressure;
+    private int humidity;
+    private float visibility;
+    private int predictability;
+
+    // Constructor with all properties
+    public WeatherReportModel(int id, String weather_state_name, String weather_state_abbr, String wind_direction_compass, String created, String applicable_date, float min_temp, float max_temp, float the_temp, float wind_speed, float wind_direction, int air_pressure, int humidity, float visibility, int predictability) {
+        this.id = id;
+        this.weather_state_name = weather_state_name;
+        this.weather_state_abbr = weather_state_abbr;
+        this.wind_direction_compass = wind_direction_compass;
+        this.created = created;
+        this.applicable_date = applicable_date;
+        this.min_temp = min_temp;
+        this.max_temp = max_temp;
+        this.the_temp = the_temp;
+        this.wind_speed = wind_speed;
+        this.wind_direction = wind_direction;
+        this.air_pressure = air_pressure;
+        this.humidity = humidity;
+        this.visibility = visibility;
+        this.predictability = predictability;
+    }
+
+    // Constructor with no properties
+    public WeatherReportModel() {
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getWeather_state_name() {
+        return weather_state_name;
+    }
+
+    public void setWeather_state_name(String weather_state_name) {
+        this.weather_state_name = weather_state_name;
+    }
+
+    public String getWeather_state_abbr() {
+        return weather_state_abbr;
+    }
+
+    public void setWeather_state_abbr(String weather_state_abbr) {
+        this.weather_state_abbr = weather_state_abbr;
+    }
+
+    public String getWind_direction_compass() {
+        return wind_direction_compass;
+    }
+
+    public void setWind_direction_compass(String wind_direction_compass) {
+        this.wind_direction_compass = wind_direction_compass;
+    }
+
+    public String getCreated() {
+        return created;
+    }
+
+    public void setCreated(String created) {
+        this.created = created;
+    }
+
+    public String getApplicable_date() {
+        return applicable_date;
+    }
+
+    public void setApplicable_date(String applicable_date) {
+        this.applicable_date = applicable_date;
+    }
+
+    public float getMin_temp() {
+        return min_temp;
+    }
+
+    public void setMin_temp(float min_temp) {
+        this.min_temp = min_temp;
+    }
+
+    public float getMax_temp() {
+        return max_temp;
+    }
+
+    public void setMax_temp(float max_temp) {
+        this.max_temp = max_temp;
+    }
+
+    public float getThe_temp() {
+        return the_temp;
+    }
+
+    public void setThe_temp(float the_temp) {
+        this.the_temp = the_temp;
+    }
+
+    public float getWind_speed() {
+        return wind_speed;
+    }
+
+    public void setWind_speed(float wind_speed) {
+        this.wind_speed = wind_speed;
+    }
+
+    public float getWind_direction() {
+        return wind_direction;
+    }
+
+    public void setWind_direction(float wind_direction) {
+        this.wind_direction = wind_direction;
+    }
+
+    public int getAir_pressure() {
+        return air_pressure;
+    }
+
+    public void setAir_pressure(int air_pressure) {
+        this.air_pressure = air_pressure;
+    }
+
+    public int getHumidity() {
+        return humidity;
+    }
+
+    public void setHumidity(int humidity) {
+        this.humidity = humidity;
+    }
+
+    public float getVisibility() {
+        return visibility;
+    }
+
+    public void setVisibility(float visibility) {
+        this.visibility = visibility;
+    }
+
+    public int getPredictability() {
+        return predictability;
+    }
+
+    public void setPredictability(int predictability) {
+        this.predictability = predictability;
+    }
+
+    @Override
+    public String toString() {
+        return "WeatherReportModel{" +
+                "id=" + id +
+                ", weather_state_name='" + weather_state_name + '\'' +
+                ", weather_state_abbr='" + weather_state_abbr + '\'' +
+                ", wind_direction_compass='" + wind_direction_compass + '\'' +
+                ", created='" + created + '\'' +
+                ", applicable_date='" + applicable_date + '\'' +
+                ", min_temp=" + min_temp +
+                ", max_temp=" + max_temp +
+                ", the_temp=" + the_temp +
+                ", wind_speed=" + wind_speed +
+                ", wind_direction=" + wind_direction +
+                ", air_pressure=" + air_pressure +
+                ", humidity=" + humidity +
+                ", visibility=" + visibility +
+                ", predictability=" + predictability +
+                '}';
+    }
+}

--- a/app/src/main/java/com/cp3407/wildernessweather/WeatherReportModel.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/WeatherReportModel.java
@@ -3,8 +3,7 @@ package com.cp3407.wildernessweather;
 public class WeatherReportModel {
 
     // Properties from metaweather REST api data
-
-    private int id;
+    private long id;
     private String weather_state_name;
     private String weather_state_abbr;
     private String wind_direction_compass;
@@ -21,7 +20,7 @@ public class WeatherReportModel {
     private int predictability;
 
     // Constructor with all properties
-    public WeatherReportModel(int id, String weather_state_name, String weather_state_abbr, String wind_direction_compass, String created, String applicable_date, float min_temp, float max_temp, float the_temp, float wind_speed, float wind_direction, int air_pressure, int humidity, float visibility, int predictability) {
+    public WeatherReportModel(long id, String weather_state_name, String weather_state_abbr, String wind_direction_compass, String created, String applicable_date, float min_temp, float max_temp, float the_temp, float wind_speed, float wind_direction, int air_pressure, int humidity, float visibility, int predictability) {
         this.id = id;
         this.weather_state_name = weather_state_name;
         this.weather_state_abbr = weather_state_abbr;
@@ -43,11 +42,11 @@ public class WeatherReportModel {
     public WeatherReportModel() {
     }
 
-    public int getId() {
+    public long getId() {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(long id) {
         this.id = id;
     }
 
@@ -167,20 +166,20 @@ public class WeatherReportModel {
     public String toString() {
         return "WeatherReportModel{" +
                 "id=" + id +
-                ", weather_state_name='" + weather_state_name + '\'' +
-                ", weather_state_abbr='" + weather_state_abbr + '\'' +
-                ", wind_direction_compass='" + wind_direction_compass + '\'' +
-                ", created='" + created + '\'' +
-                ", applicable_date='" + applicable_date + '\'' +
-                ", min_temp=" + min_temp +
-                ", max_temp=" + max_temp +
-                ", the_temp=" + the_temp +
-                ", wind_speed=" + wind_speed +
-                ", wind_direction=" + wind_direction +
-                ", air_pressure=" + air_pressure +
-                ", humidity=" + humidity +
-                ", visibility=" + visibility +
-                ", predictability=" + predictability +
+                "weather_state_name='" + weather_state_name + "\n" +
+                "weather_state_abbr='" + weather_state_abbr + "\n" +
+                "wind_direction_compass='" + wind_direction_compass + "\n" +
+                "created='" + created + "\n" +
+                "applicable_date='" + applicable_date + "\n" +
+                "min_temp=" + min_temp + "\n" +
+                "max_temp=" + max_temp + "\n" +
+                "the_temp=" + the_temp + "\n" +
+                "wind_speed=" + wind_speed + "\n" +
+                "wind_direction=" + wind_direction + "\n" +
+                "air_pressure=" + air_pressure + "\n" +
+                "humidity=" + humidity + "\n" +
+                "visibility=" + visibility + "\n" +
+                "predictability=" + predictability +
                 '}';
     }
 }

--- a/app/src/main/res/layout/activity_apiactivity.xml
+++ b/app/src/main/res/layout/activity_apiactivity.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".APIactivity">
+
+    <EditText
+        android:id="@+id/et_searchBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="City name or ID" />
+
+    <Button
+        android:id="@+id/btn_getWeatherData"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:onClick="getWeatherPressed"
+        android:text="Press for weather data" />
+
+    <ListView
+        android:id="@+id/lv_weatherReports"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,11 +8,18 @@
     tools:context=".MainActivity">
 
     <Button
-        android:id="@+id/btn_getWeather"
+        android:id="@+id/btn_getCityID"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:onClick="getCityIdPressed"
+        android:text="Press me for Brisbane's city ID" />
+
+    <Button
+        android:id="@+id/btn_getWeatherData"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:onClick="getWeatherPressed"
-        android:text="Press me for weather" />
+        android:text="Press me for weather data" />
 
     <TextView
         android:id="@+id/tv_weatherView"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,6 +11,7 @@
         android:id="@+id/btn_getWeather"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:onClick="getWeatherPressed"
         android:text="Press me for weather" />
 
     <TextView

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,10 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     tools:context=".MainActivity">
+
+    <Button
+        android:id="@+id/btn_getWeather"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Press me for weather" />
+
+    <TextView
+        android:id="@+id/tv_weatherView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Weather data should appear here" />
 
     <TextView
         android:layout_width="wrap_content"
@@ -15,4 +28,4 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,24 +8,11 @@
     tools:context=".MainActivity">
 
     <Button
-        android:id="@+id/btn_getCityID"
+        android:id="@+id/btn_apiPrototype"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:onClick="getCityIdPressed"
-        android:text="Press me for Brisbane's city ID" />
-
-    <Button
-        android:id="@+id/btn_getWeatherData"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:onClick="getWeatherPressed"
-        android:text="Press me for weather data" />
-
-    <TextView
-        android:id="@+id/tv_weatherView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="Weather data should appear here" />
+        android:onClick="apiPrototypePressed"
+        android:text="Press for API Prototype" />
 
     <TextView
         android:layout_width="wrap_content"


### PR DESCRIPTION
# What is in this PR?
This PR will add a `WeatherDataService` to our app that fetches weather information from [metaweather.com](https://www.metaweather.com) for a given location, and a `WeatherReportModel` to contain the weather information. 

## Roadmap
- [x] Request JSON data
- [x] Create Singleton 
- [x] Create callback method
- [x] Extract data from JSON object
- [x] Refactor to remove prototyping code

## Usage
The `WeatherDataService` class has 2 methods, `getCityID` and `getCityForecastByID`. These do exactly what they say on the tin - `getCityID` returns a city ID number, and `getCityForecastByID` returns a weather forecast for the next 6 days. Metaweather's API for the forecast doesn't work with location names, which is why we must first use the `getCityID` method.

**Example**

1. A user types Brisbane into the search field and presses the search button
2. `getCityID` is called, which sends `https://www.metaweather.com/api/location/search/?query=brisbane` to Metaweather.
3. 
```json
[
  {
    "title": "Brisbane",
    "location_type": "City",
    "woeid": 1100661,
    "latt_long": "-27.468880,153.022827"
  }
]
```
is returned, and the `woeid` value of 1100661 is stored.
4. `getCityForecastByID` is then called, using the query `https://www.metaweather.com/api/location/1100661`
5. A JSON object is returned containing weather for the next 6 days, and 6 new `WeatherDataModel` objects are created using the properties from the JSON object. 

**Note** - [Metaweather only suppports 5 cities in Australia](https://www.metaweather.com/23424748/), but as this is just a proof-of-concept prototype at the moment it shouldn't matter. We can refactor this to suit whichever weather API we choose to use.