### PR TITLE
Settings shared preferences

### DIFF
--- a/app/src/main/java/com/cp3407/wildernessweather/APIactivity.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/APIactivity.java
@@ -1,11 +1,12 @@
 package com.cp3407.wildernessweather;
 
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.widget.AdapterView;
-import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ListView;
@@ -18,6 +19,7 @@ import org.parceler.Parcels;
 import java.util.ArrayList;
 
 public class APIactivity extends AppCompatActivity {
+    private SharedPreferences settingsData;
 
     EditText searchBox;
     Button getWeatherData;
@@ -28,6 +30,8 @@ public class APIactivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_apiactivity);
+
+        settingsData = getSharedPreferences("settings", Context.MODE_PRIVATE);
 
         searchBox = findViewById(R.id.et_searchBox);
         getWeatherData = findViewById(R.id.btn_getWeatherData);
@@ -46,7 +50,8 @@ public class APIactivity extends AppCompatActivity {
 
             @Override
             public void onResponse(ArrayList<WeatherReportModel> weatherReportModels) {
-                WeatherReportModelListAdapter arrayAdapter = new WeatherReportModelListAdapter(APIactivity.this, R.layout.weather_report_list_item, weatherReportModels);
+                boolean isMetric = settingsData.getBoolean("isMetric", true);
+                WeatherReportModelListAdapter arrayAdapter = new WeatherReportModelListAdapter(APIactivity.this, R.layout.weather_report_list_item, weatherReportModels, isMetric);
                 weatherReports.setAdapter(arrayAdapter);
 
                 weatherReports.setClickable(true);

--- a/app/src/main/java/com/cp3407/wildernessweather/SingleWeatherReportActivity.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/SingleWeatherReportActivity.java
@@ -3,7 +3,9 @@ package com.cp3407.wildernessweather;
 import android.app.AlertDialog;
 import android.app.DatePickerDialog;
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
@@ -13,8 +15,6 @@ import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
-
-import androidx.appcompat.widget.Toolbar;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
@@ -26,6 +26,8 @@ import org.parceler.Parcels;
 import java.util.Calendar;
 
 public class SingleWeatherReportActivity extends AppCompatActivity {
+    private SharedPreferences settingsData;
+
     WeatherReportModel singleWeatherReport;
     WeatherReportViewModel viewModel;
     WeatherDataService weatherDataService;
@@ -45,8 +47,6 @@ public class SingleWeatherReportActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_single_weather_report);
 
-//        Toolbar myToolbar = (Toolbar) findViewById(R.id.app_bar);
-//        setSupportActionBar(myToolbar);
 
         cityNameView = findViewById(R.id.tv_cityName);
         stateView = findViewById(R.id.tv_weatherStateName);
@@ -68,7 +68,11 @@ public class SingleWeatherReportActivity extends AppCompatActivity {
         weatherDataService = new WeatherDataService(SingleWeatherReportActivity.this);
 
         singleWeatherReport = Parcels.unwrap(getIntent().getParcelableExtra("report"));
-        populateFields();
+
+        settingsData = getSharedPreferences("settings", Context.MODE_PRIVATE);
+        boolean isMetric = settingsData.getBoolean("isMetric", true);
+        populateFields(isMetric);
+        Log.i("single", "minTemp = " + singleWeatherReport.getTheTemp() + ". MinTempImp = " + singleWeatherReport.getTheTempImperial());
 
         applicableDateView.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -169,22 +173,43 @@ public class SingleWeatherReportActivity extends AppCompatActivity {
         });
     }
 
-    public void populateFields() {
-        cityNameView.setText(String.valueOf(singleWeatherReport.getCityName()));
-        stateView.setText(singleWeatherReport.getWeatherStateName());
-        // Set weather state image field to correct resource.
-        stateImage.setImageResource(getStateImageResId(singleWeatherReport.getWeatherStateAbbr()));
-        // Convert date string before inserting.
-        applicableDateView.setText(String.valueOf(convertDateString(singleWeatherReport.getApplicableDate())));
-        minTempView.setText(" " + Math.round(singleWeatherReport.getMinTemp()) + "°");
-        maxTempView.setText(" " + Math.round(singleWeatherReport.getMaxTemp()) + "°");
-        tempView.setText(" " + Math.round(singleWeatherReport.getTheTemp()) + "°");
-        windSpeedView.setText((Math.round(singleWeatherReport.getWindSpeed() * 100.0) / 100.0) + " Km/h");
-        windDirectionView.setText(singleWeatherReport.getWindDirectionCompass() + " (" + Math.round(singleWeatherReport.getWindDirection()) + "°)");
-        airPressureView.setText(singleWeatherReport.getAirPressure() + " in");
-        humidityView.setText(singleWeatherReport.getHumidity() + "%");
-        visibilityView.setText((Math.round(singleWeatherReport.getVisibility() * 100.0) / 100.0) + "mi");
-        predictabilityView.setText(singleWeatherReport.getPredictability() + "%");
+    public void populateFields(boolean isMetric) {
+        if (isMetric) {
+            cityNameView.setText(String.valueOf(singleWeatherReport.getCityName()));
+            stateView.setText(singleWeatherReport.getWeatherStateName());
+            // Set weather state image field to correct resource.
+            stateImage.setImageResource(getStateImageResId(singleWeatherReport.getWeatherStateAbbr()));
+            // Convert date string before inserting.
+            applicableDateView.setText(String.valueOf(convertDateString(singleWeatherReport.getApplicableDate())));
+            minTempView.setText(" " + Math.round(singleWeatherReport.getMinTemp()) + "°");
+            maxTempView.setText(" " + Math.round(singleWeatherReport.getMaxTemp()) + "°");
+            tempView.setText(" " + Math.round(singleWeatherReport.getTheTemp()) + "°");
+            windSpeedView.setText((Math.round(singleWeatherReport.getWindSpeed() * 100.0) / 100.0) + " Km/h");
+            windDirectionView.setText(singleWeatherReport.getWindDirectionCompass() + " (" + Math.round(singleWeatherReport.getWindDirection()) + "°)");
+            airPressureView.setText(singleWeatherReport.getAirPressure() + " hPa");
+            humidityView.setText(singleWeatherReport.getHumidity() + "%");
+            visibilityView.setText((Math.round(singleWeatherReport.getVisibility() * 100.0) / 100.0) + "km");
+            predictabilityView.setText(singleWeatherReport.getPredictability() + "%");
+        } else {
+            // TODO change the vales to the imperial system
+
+            cityNameView.setText(String.valueOf(singleWeatherReport.getCityName()));
+            stateView.setText(singleWeatherReport.getWeatherStateName());
+            // Set weather state image field to correct resource.
+            stateImage.setImageResource(getStateImageResId(singleWeatherReport.getWeatherStateAbbr()));
+            // Convert date string before inserting.
+            applicableDateView.setText(String.valueOf(convertDateString(singleWeatherReport.getApplicableDate())));
+            minTempView.setText(" " + Math.round(singleWeatherReport.getMinTempImperial()) + "°");
+            maxTempView.setText(" " + Math.round(singleWeatherReport.getMaxTempImperial()) + "°");
+            tempView.setText(" " + Math.round(singleWeatherReport.getTheTempImperial()) + "°");
+            windSpeedView.setText((Math.round(singleWeatherReport.getWindSpeedImperial() * 100.0) / 100.0) + " mph");
+            windDirectionView.setText(singleWeatherReport.getWindDirectionCompass() + " (" + Math.round(singleWeatherReport.getWindDirection()) + "°)");
+            airPressureView.setText(singleWeatherReport.getAirPressure() + " hPa");
+            humidityView.setText(singleWeatherReport.getHumidity() + "%");
+            visibilityView.setText((Math.round(singleWeatherReport.getVisibilityImperial() * 100.0) / 100.0) + "mi");
+            predictabilityView.setText(singleWeatherReport.getPredictability() + "%");
+        }
+
     }
 
     /**

--- a/app/src/main/java/com/cp3407/wildernessweather/SingleWeatherReportActivity.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/SingleWeatherReportActivity.java
@@ -46,7 +46,7 @@ public class SingleWeatherReportActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_single_weather_report);
-
+        settingsData = getSharedPreferences("settings", Context.MODE_PRIVATE);
 
         cityNameView = findViewById(R.id.tv_cityName);
         stateView = findViewById(R.id.tv_weatherStateName);
@@ -69,10 +69,8 @@ public class SingleWeatherReportActivity extends AppCompatActivity {
 
         singleWeatherReport = Parcels.unwrap(getIntent().getParcelableExtra("report"));
 
-        settingsData = getSharedPreferences("settings", Context.MODE_PRIVATE);
         boolean isMetric = settingsData.getBoolean("isMetric", true);
         populateFields(isMetric);
-        Log.i("single", "minTemp = " + singleWeatherReport.getTheTemp() + ". MinTempImp = " + singleWeatherReport.getTheTempImperial());
 
         applicableDateView.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/java/com/cp3407/wildernessweather/WeatherReportListAdapter.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/WeatherReportListAdapter.java
@@ -95,7 +95,6 @@ public class WeatherReportListAdapter extends RecyclerView.Adapter<WeatherReport
         // Sets onClickListeners
         public void setListeners() {
             // Code here runs whenever an item in the recyclerView is pressed
-            // TODO change so user can click anywhere on the list item, not just the ID number
             listItem.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {

--- a/app/src/main/java/com/cp3407/wildernessweather/WeatherReportModel.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/WeatherReportModel.java
@@ -137,12 +137,20 @@ public class WeatherReportModel {
         return minTemp;
     }
 
+    public float getMinTempImperial() {
+        return (float) ((minTemp * 1.8) + 32);
+    }
+
     public void setMinTemp(float minTemp) {
         this.minTemp = minTemp;
     }
 
     public float getMaxTemp() {
         return maxTemp;
+    }
+
+    public float getMaxTempImperial() {
+        return (float) ((maxTemp * 1.8) + 32);
     }
 
     public void setMaxTemp(float maxTemp) {
@@ -153,11 +161,19 @@ public class WeatherReportModel {
         return theTemp;
     }
 
+    public float getTheTempImperial() {
+        return (float) ((theTemp * 1.8) + 32);
+    }
+
     public void setTheTemp(float theTemp) {
         this.theTemp = theTemp;
     }
 
     public float getWindSpeed() {
+        return (float) (windSpeed * 1.60934);
+    }
+
+    public float getWindSpeedImperial() {
         return windSpeed;
     }
 
@@ -190,7 +206,11 @@ public class WeatherReportModel {
     }
 
     public float getVisibility() {
-        return visibility;
+        return (float) (visibility * 1.60934);
+    }
+
+    public float getVisibilityImperial() {
+        return (visibility);
     }
 
     public void setVisibility(float visibility) {

--- a/app/src/main/java/com/cp3407/wildernessweather/WeatherReportModelListAdapter.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/WeatherReportModelListAdapter.java
@@ -16,18 +16,30 @@ public class WeatherReportModelListAdapter extends ArrayAdapter<WeatherReportMod
 
     private Context mContext;
     int mResource;
+    boolean isMetric;
 
-    public WeatherReportModelListAdapter(Context context, int resource, ArrayList<WeatherReportModel> objects) {
+    public WeatherReportModelListAdapter(Context context, int resource, ArrayList<WeatherReportModel> objects, boolean isMetric) {
         super(context, resource, objects);
         mContext = context;
         mResource = resource;
+        this.isMetric = isMetric;
     }
 
     public View getView(int position, View convertView, ViewGroup parent) {
         String cityName = getItem(position).getCityName();
         String weatherStateAbbr = getItem(position).getWeatherStateAbbr();
-        float minTemp = getItem(position).getMinTemp();
-        float maxTemp = getItem(position).getMaxTemp();
+        float minTemp;
+        float maxTemp;
+
+        if (isMetric) {
+            minTemp = getItem(position).getMinTemp();
+            maxTemp = getItem(position).getMaxTemp();
+
+        } else {
+            minTemp = getItem(position).getMinTempImperial();
+            maxTemp = getItem(position).getMaxTempImperial();
+        }
+
         LayoutInflater inflater = LayoutInflater.from(mContext);
         convertView = inflater.inflate(mResource, parent, false);
 

--- a/app/src/main/java/com/cp3407/wildernessweather/settings/DisplaySettingsActivity.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/settings/DisplaySettingsActivity.java
@@ -8,7 +8,7 @@ import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.Spinner;
-import android.widget.Switch;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SwitchCompat;
@@ -22,7 +22,10 @@ public class DisplaySettingsActivity extends AppCompatActivity implements Adapte
     private SwitchCompat darkModeSwitch;
     private Spinner unitsOfMeasurementSpinner;
     private Spinner fontSizeSpinner;
-    private Button saveButton;
+
+    private boolean isDarkMode;
+    private boolean isMetric;
+    private boolean isRegular;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -35,7 +38,10 @@ public class DisplaySettingsActivity extends AppCompatActivity implements Adapte
         darkModeSwitch = findViewById(R.id.sw_darkmode);
         unitsOfMeasurementSpinner = findViewById(R.id.spin_unitOfMeasurement);
         fontSizeSpinner = findViewById(R.id.spin_fontSize);
-        saveButton = findViewById(R.id.btn_saveDisplaySettings);
+
+        isDarkMode = settingsData.getBoolean("isDarkMode", false);
+        isMetric = settingsData.getBoolean("isMetric", true);
+        isRegular = settingsData.getBoolean("isRegular", true);
 
         initialiseSettings();
     }
@@ -43,22 +49,15 @@ public class DisplaySettingsActivity extends AppCompatActivity implements Adapte
 
     // Initialises the UI and restores the displayed settings to what is stored in SharedPrefs
     private void initialiseSettings() {
-
-        boolean isDarkMode = settingsData.getBoolean("isDarkMode", false);
-        boolean isMetric = settingsData.getBoolean("isMetric", true);
-        boolean isRegular = settingsData.getBoolean("isRegular", true);
-
-        setSwitch(isDarkMode);
-        setArrayAdapters(isMetric, isRegular);
-    }
-
-    private void setSwitch(boolean isDarkMode) {
+        // Sets the value of the switch
         darkModeSwitch.setChecked(isDarkMode);
+
+        // Sets the values of the spinners using array adapters
+        setArrayAdapters();
     }
 
-    // This method sets the values of the spinners using array adapters
-    public void setArrayAdapters(boolean isMetric, boolean isRegular) {
 
+    public void setArrayAdapters() {
         // Array adapter for units of measurement spinner
         ArrayAdapter<CharSequence> unitsOfMeasurementAdapter = ArrayAdapter.createFromResource(this, R.array.units_of_measurement, R.layout.spinner_item);
         unitsOfMeasurementAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
@@ -76,10 +75,24 @@ public class DisplaySettingsActivity extends AppCompatActivity implements Adapte
         fontSizeSpinner.setAdapter(textSizeAdapter);
         fontSizeSpinner.setOnItemSelectedListener(this);
         if (isRegular) {
-            fontSizeSpinner.setSelection(0);
+            fontSizeSpinner.setSelection(0); // 0 = regular font size, 1 = large font size
         } else {
             fontSizeSpinner.setSelection(1);
         }
+
+    }
+
+    // Save selections to SharedPreferences
+    public void savePressed(View view) {
+        SharedPreferences.Editor editor = settingsData.edit();
+
+        editor.putBoolean("isDarkMode", darkModeSwitch.isChecked());
+        editor.putBoolean("isMetric", unitsOfMeasurementSpinner.getSelectedItemPosition() == 0);
+        editor.putBoolean("isRegular", fontSizeSpinner.getSelectedItemPosition() == 0);
+        editor.apply();
+
+        Toast.makeText(DisplaySettingsActivity.this, "Settings Saved", Toast.LENGTH_SHORT).show();
+        finish();
     }
 
     @Override
@@ -92,8 +105,4 @@ public class DisplaySettingsActivity extends AppCompatActivity implements Adapte
         // do nothing
     }
 
-    public void savePressed(View view) {
-        // save selections to SharedPreferences
-        // Go back to SettingsActivity
-    }
 }

--- a/app/src/main/java/com/cp3407/wildernessweather/settings/DisplaySettingsActivity.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/settings/DisplaySettingsActivity.java
@@ -1,19 +1,28 @@
 package com.cp3407.wildernessweather.settings;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
+import android.widget.Button;
 import android.widget.Spinner;
+import android.widget.Switch;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.SwitchCompat;
 
 import com.cp3407.wildernessweather.R;
 
 public class DisplaySettingsActivity extends AppCompatActivity implements AdapterView.OnItemSelectedListener {
 
+    private SharedPreferences settingsData;
+
+    private SwitchCompat darkModeSwitch;
     private Spinner unitsOfMeasurementSpinner;
     private Spinner fontSizeSpinner;
+    private Button saveButton;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -21,26 +30,56 @@ public class DisplaySettingsActivity extends AppCompatActivity implements Adapte
         setContentView(R.layout.activity_display_settings);
         this.setTitle("Display Settings");
 
+        settingsData = getSharedPreferences("settings", Context.MODE_PRIVATE);
+
+        darkModeSwitch = findViewById(R.id.sw_darkmode);
         unitsOfMeasurementSpinner = findViewById(R.id.spin_unitOfMeasurement);
         fontSizeSpinner = findViewById(R.id.spin_fontSize);
+        saveButton = findViewById(R.id.btn_saveDisplaySettings);
 
-        setArrayAdapters();
+        initialiseSettings();
+    }
+
+
+    // Initialises the UI and restores the displayed settings to what is stored in SharedPrefs
+    private void initialiseSettings() {
+
+        boolean isDarkMode = settingsData.getBoolean("isDarkMode", false);
+        boolean isMetric = settingsData.getBoolean("isMetric", true);
+        boolean isRegular = settingsData.getBoolean("isRegular", true);
+
+        setSwitch(isDarkMode);
+        setArrayAdapters(isMetric, isRegular);
+    }
+
+    private void setSwitch(boolean isDarkMode) {
+        darkModeSwitch.setChecked(isDarkMode);
     }
 
     // This method sets the values of the spinners using array adapters
-    public void setArrayAdapters() {
+    public void setArrayAdapters(boolean isMetric, boolean isRegular) {
+
         // Array adapter for units of measurement spinner
         ArrayAdapter<CharSequence> unitsOfMeasurementAdapter = ArrayAdapter.createFromResource(this, R.array.units_of_measurement, R.layout.spinner_item);
         unitsOfMeasurementAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         unitsOfMeasurementSpinner.setAdapter(unitsOfMeasurementAdapter);
-
         unitsOfMeasurementSpinner.setOnItemSelectedListener(this);
+        if (isMetric) {
+            unitsOfMeasurementSpinner.setSelection(0); // 0 = metric, 1 = imperial
+        } else {
+            unitsOfMeasurementSpinner.setSelection(1);
+        }
 
         // Array adapter for font size spinner
         ArrayAdapter<CharSequence> textSizeAdapter = ArrayAdapter.createFromResource(this, R.array.font_sie, R.layout.spinner_item);
         textSizeAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         fontSizeSpinner.setAdapter(textSizeAdapter);
         fontSizeSpinner.setOnItemSelectedListener(this);
+        if (isRegular) {
+            fontSizeSpinner.setSelection(0);
+        } else {
+            fontSizeSpinner.setSelection(1);
+        }
     }
 
     @Override
@@ -50,11 +89,11 @@ public class DisplaySettingsActivity extends AppCompatActivity implements Adapte
 
     @Override
     public void onNothingSelected(AdapterView<?> adapterView) {
-
+        // do nothing
     }
 
     public void savePressed(View view) {
-        // TODO Sprint 2: save selections to SharedPreferences
+        // save selections to SharedPreferences
         // Go back to SettingsActivity
     }
 }

--- a/app/src/main/res/layout/activity_display_settings.xml
+++ b/app/src/main/res/layout/activity_display_settings.xml
@@ -24,7 +24,6 @@
         android:orientation="horizontal"
         android:paddingStart="20dp">
 
-        <!--        TODO create spinners - need string arrays showing options-->
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="match_parent"


### PR DESCRIPTION
# Overview
This PR merges code that allows settings to be saved inside a SharedPreferences container. 

## Changes
- `WeatherReportModel` has some new methods inside, that return imperial values. For example, `getMinTempImperial()` returns the temperature in Fahrenheit instead of Celsius:
```java
public float getMinTempImperial() {
        return (float) ((minTemp * 1.8) + 32);
    }
```
- `WeatherReportModelListAdapter` has been modified to accept a new `Boolean` parameter, `isMetric`. This value is read from the Shared Preferences container, and allows `WeatherReportModelListAdapter` to determine whether to display metric or imperial values.

## Testing
You can easily test the code yourself by:
- Searching for a location, viewing it's weather and making a note of the values displayed for the temperature and distances (**visibility** and **windspeed**).
- Performing the conversion calculation yourself, and recording the answer
- Going to the Display Settings page of our app and selecting Imperial
- View the same weather report again, and compare the converted values
- To check the shared preferences are persistent, restart the app, and check that Imperial is still selected, even after the emulator has been restarted.

## Notes
I have only added functionality for the unit of measurements settings, nothing else. I think we have bitten off more than we can chew with all the other settings involved, seeing as we have just a couple days left. If there is time at the end we can work on more functionality, but I think the units of measurement is the most important one to deliver in this "Pre-Alpha" release.
This PR closes #38.