### PR TITLE
Insert List<WeatherReportModel> into ExternalBaseIntegration

### DIFF
--- a/app/src/main/java/com/cp3407/wildernessweather/ExternalDatabaseActivity.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/ExternalDatabaseActivity.java
@@ -1,9 +1,5 @@
 package com.cp3407.wildernessweather;
 
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -11,10 +7,16 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import com.cp3407.wildernessweather.database.ExternalBaseIntegration;
 import com.cp3407.wildernessweather.database.WeatherReportViewModel;
 
 import java.sql.Connection;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ExternalDatabaseActivity extends AppCompatActivity implements WeatherReportListAdapter.OnDeleteClickListener {
@@ -24,7 +26,10 @@ public class ExternalDatabaseActivity extends AppCompatActivity implements Weath
     Connection con;
     private WeatherReportListAdapter adapter;
     List<WeatherReportModel> databaseOutput;
+    List<WeatherReportModel> jacksList;
     ListView lv_display;
+
+    boolean isReady;
 
     private WeatherReportViewModel viewModel;
     private RecyclerView recyclerView;
@@ -35,30 +40,40 @@ public class ExternalDatabaseActivity extends AppCompatActivity implements Weath
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_external_database);
 
+        viewModel = new ViewModelProvider(this).get(WeatherReportViewModel.class);
+
         tv_connectionStatus = findViewById(R.id.connectionStatus);
         tv_databaseDisplay = findViewById(R.id.databaseString);
         btn_getData = findViewById(R.id.getData);
         btn_retryConnection = findViewById(R.id.retryConButton);
+
+        isReady = false;
+
+        jacksList = new ArrayList<>();
+
 
         recyclerView = findViewById(R.id.weatherReportList);
         adapter = new WeatherReportListAdapter(this, this);
         recyclerView.setAdapter(adapter);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
 
+
         // Begin ASync task to collect data from database.
-        createAsyncTask();
+        viewModel.getAllWeatherReports().observe(this, weatherReportModels -> {
+            jacksList = weatherReportModels;
+            createAsyncTask();
+        });
     }
 
-    private void createAsyncTask(){
-        asyncTask = new ExternalBaseIntegration(new ExternalBaseIntegration.AsyncResponse() {
+    private void createAsyncTask() {
+        asyncTask = new ExternalBaseIntegration(jacksList, new ExternalBaseIntegration.AsyncResponse() {
             @Override
             public void processFinish(Object output) {
-                if (output == null){
+                if (output == null) {
                     tv_connectionStatus.setText("Failed");
                     btn_retryConnection.setVisibility(View.VISIBLE);
                     asyncTask.cancel(true);
-                }
-                else{
+                } else {
                     tv_connectionStatus.setText("Connected. Fetching data from External DB...");
 
                     databaseOutput = (List<WeatherReportModel>) output;
@@ -79,7 +94,7 @@ public class ExternalDatabaseActivity extends AppCompatActivity implements Weath
 //        displayExternalDatabase();
     }
 
-    public void retryConnectionPressed(View view){
+    public void retryConnectionPressed(View view) {
         btn_retryConnection.setVisibility(View.INVISIBLE);
         asyncTask.cancel(true);
         tv_connectionStatus.setText("Attempting to reconnect...");


### PR DESCRIPTION
Hey @HarperThurlow here's a quick and dirty solution to getting the contents of the internal database into the external database. I've just added an argument to `ExternalBaseIntegration's` constructor so it now accepts a `List<WeatherReportModel`. Inside the `onCreate` method of `ExternalDatabaseActivity` a `viewModel` is being used to retrieve the internal database contents. The `createAsyncTask()` method call is inside the `viewModel` lamdba, because the retrieving of the internal database takes a couple seconds and is run concurrently to the UI thread (if `creaateAsyncTask()` is called outside of this lambda then an empty list is passed to `ExternalBaseIntegration` as it hasn't been populated yet.)

I've left some logcat messages inside the `for loop` in the `writeToDatabase()` function so you can see that the list is successfully being called (it prints the cityNames of each database entry).

Hope this can help