### PR TITLE
Add favourites to shared prefs

### DIFF
--- a/app/src/main/java/com/cp3407/wildernessweather/MainActivity.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/MainActivity.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.util.Log;
 import android.widget.ImageButton;
 import android.widget.ListView;
 import android.widget.SearchView;
@@ -15,7 +16,6 @@ import com.cp3407.wildernessweather.settings.SettingsActivity;
 
 import org.parceler.Parcels;
 
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashSet;
 import java.util.Locale;
@@ -108,11 +108,9 @@ public class MainActivity extends AppCompatActivity {
 
 
     public void initialiseList() {
-
-        dummySetSharedPreferences();
-        String[] cityNames = getFavCityNames();
+        String[] favouriteLocations = getFavCityNames();
         boolean isMetric = settingsData.getBoolean("isMetric", true);
-        weatherDataService.getFavourites(cityNames, weatherReportModels -> {
+        weatherDataService.getFavourites(favouriteLocations, weatherReportModels -> {
             WeatherReportModelListAdapter adapter = new WeatherReportModelListAdapter(MainActivity.this, R.layout.weather_report_list_item, weatherReportModels, isMetric);
             locationList.setAdapter(adapter);
             locationList.setOnItemClickListener((adapterView, view, i, l) -> {
@@ -124,23 +122,10 @@ public class MainActivity extends AppCompatActivity {
         });
     }
 
-    public void dummySetSharedPreferences() {
-        String[] testCityNames = {"Rome", "Paris", "New York"};
-
-        Set<String> citiesAsSet = convertArrayToSet(testCityNames);
-        SharedPreferences.Editor editor = favourites.edit();
-        editor.putStringSet("locations", citiesAsSet);
-
-        editor.apply();
-    }
-
     public String[] getFavCityNames() {
         Set<String> cityNamesAsSet = favourites.getStringSet("locations", new HashSet<>());
+        Log.i("favourites", "favourites: " + cityNamesAsSet);
         return convertSetToArray(cityNamesAsSet);
-    }
-
-    public <T> Set<T> convertArrayToSet(T[] array) {
-        return new HashSet<>(Arrays.asList(array));
     }
 
     public String[] convertSetToArray(Set<String> setOfString) {

--- a/app/src/main/java/com/cp3407/wildernessweather/SingleWeatherReportActivity.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/SingleWeatherReportActivity.java
@@ -24,9 +24,12 @@ import com.cp3407.wildernessweather.database.WeatherReportViewModel;
 import org.parceler.Parcels;
 
 import java.util.Calendar;
+import java.util.HashSet;
+import java.util.Set;
 
 public class SingleWeatherReportActivity extends AppCompatActivity {
     private SharedPreferences settingsData;
+    private SharedPreferences favourites;
 
     WeatherReportModel singleWeatherReport;
     WeatherReportViewModel viewModel;
@@ -47,6 +50,7 @@ public class SingleWeatherReportActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_single_weather_report);
         settingsData = getSharedPreferences("settings", Context.MODE_PRIVATE);
+        favourites = getSharedPreferences("favourites", Context.MODE_PRIVATE);
 
         cityNameView = findViewById(R.id.tv_title);
         stateView = findViewById(R.id.tv_weatherStateName);
@@ -214,18 +218,47 @@ public class SingleWeatherReportActivity extends AppCompatActivity {
     }
 
     private void updateFavouriteButton() {
-
+        boolean isFavourite;
         final ImageButton favouriteButton = findViewById(R.id.btn_favourite);
-        favouriteButton.setImageResource(R.drawable.ic_favourite_gray);
+        // Get favourites as a set
+        Set<String> favouriteLocations = favourites.getStringSet("locations", new HashSet<>());
+
+        // If current location is in set, yellow star, else grey star
+        if (favouriteLocations.contains(singleWeatherReport.getCityName())) {
+            Log.i("favourites", "this is a favourite");
+            favouriteButton.setImageResource(R.drawable.ic_favourite);
+            isFavourite = true;
+        } else {
+            Log.i("favourites", "this is not a favourite");
+            favouriteButton.setImageResource(R.drawable.ic_favourite_gray);
+            isFavourite = false;
+        }
+
         // TODO: set button image to ic_favourite if location is in favourites, else ic_favourite_gray.
         // This means that we need to keep track of which locations we have favourited.
         favouriteButton.setOnClickListener(new View.OnClickListener() {
-            public void onClick (View v) {
-                // TODO: favourite method in WeatherReportModel.
-                favouriteButton.setImageResource(R.drawable.ic_favourite);
+            public void onClick(View v) {
+                toggleFavourite(isFavourite);
             }
         });
     }
+
+    public void toggleFavourite(boolean isFavourite) {
+        Set<String> favouriteLocations = favourites.getStringSet("locations", new HashSet<>());
+        SharedPreferences.Editor editor = favourites.edit();
+        if (isFavourite) {
+            favouriteLocations.remove(singleWeatherReport.getCityName());
+            Log.i("favourites", "removing this from favourites");
+        } else {
+            favouriteLocations.add(singleWeatherReport.getCityName());
+            Log.i("favourites", "adding this to favourites");
+        }
+        editor.putStringSet("locations", favouriteLocations);
+        editor.apply();
+        Log.i("favourites", "favourites: " + favouriteLocations);
+        updateFavouriteButton();
+    }
+
 
     /**
      * Returns the resource id of the image that corresponds to a weather state abbreviation.

--- a/app/src/main/java/com/cp3407/wildernessweather/SingleWeatherReportActivity.java
+++ b/app/src/main/java/com/cp3407/wildernessweather/SingleWeatherReportActivity.java
@@ -222,6 +222,7 @@ public class SingleWeatherReportActivity extends AppCompatActivity {
         final ImageButton favouriteButton = findViewById(R.id.btn_favourite);
         // Get favourites as a set
         Set<String> favouriteLocations = favourites.getStringSet("locations", new HashSet<>());
+        Log.i("favourites", "favourites: " + favouriteLocations);
 
         // If current location is in set, yellow star, else grey star
         if (favouriteLocations.contains(singleWeatherReport.getCityName())) {
@@ -246,19 +247,19 @@ public class SingleWeatherReportActivity extends AppCompatActivity {
     public void toggleFavourite(boolean isFavourite) {
         Set<String> favouriteLocations = favourites.getStringSet("locations", new HashSet<>());
         SharedPreferences.Editor editor = favourites.edit();
+        HashSet<String> favouriteLocationsEdited = new HashSet<String>(favouriteLocations);
         if (isFavourite) {
-            favouriteLocations.remove(singleWeatherReport.getCityName());
+            favouriteLocationsEdited.remove(singleWeatherReport.getCityName());
             Log.i("favourites", "removing this from favourites");
         } else {
-            favouriteLocations.add(singleWeatherReport.getCityName());
+            favouriteLocationsEdited.add(singleWeatherReport.getCityName());
             Log.i("favourites", "adding this to favourites");
         }
-        editor.putStringSet("locations", favouriteLocations);
+        editor.putStringSet("locations", favouriteLocationsEdited);
         editor.apply();
         Log.i("favourites", "favourites: " + favouriteLocations);
         updateFavouriteButton();
     }
-
 
     /**
      * Returns the resource id of the image that corresponds to a weather state abbreviation.


### PR DESCRIPTION
Hi @CalebWebsterJCU this PR merges some functionality in. When the favourite button is pressed, it now toggles the star between yellow for favourite, and grey for not-favourite. It also updates the sharedPreferences list. 

The favourites list on the homescreen reflects these changes, but _only_ after restarting the emulator. Issue number #50 should solve this problem. I think we just need the home-screen to redraw itself each time the user returns to it.

Please check out this code and check over it to double check everything is ok. 